### PR TITLE
[FIX] package_hierarchy: avoid issues with stock.move.line._action_do…

### DIFF
--- a/addons/package_hierarchy/models/stock_move_line.py
+++ b/addons/package_hierarchy/models/stock_move_line.py
@@ -19,7 +19,7 @@ class StockMoveLine(models.Model):
         """
         super(StockMoveLine, self)._action_done()
 
-        for ml in self:
+        for ml in self.exists():
             result_parent = ml.u_result_parent_package_id
             result_package = ml.result_package_id
             if result_parent:


### PR DESCRIPTION
…ne()

The function can delete move lines in self, so we need to filter
using .exists() just in case any of them has been deleted.

Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>