### PR TITLE
[IMP] Remove 'palletise' and 'put_in_pack' buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ This module adds the following features:
 ## To change
 * Change fields x_field_name to u_field_name
 * Stock.quant.packge has a field name called parent_ids but in the compute function uses ancestor_ids
-* Parent package is only shonw at package view if it is set, change it to be able to set it when it is emptye
+* Parent package is only shown at package view if it is set, change it to be able to set it when it is emptye
 * Packages button (top right of stock.picking.form view) only shows packages, update it to also show parent packages
 * x_selected still needed? Probably we can remove it and add it later if we need to palletise using UI

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ This module adds the following features:
 
 ## To change
 * Stock.quant.packge has a field name called parent_ids but in the compute function uses ancestor_ids
-* Parent package is only shown at package view if it is set, change it to be able to set it when it is emptye
+* Parent package is only shown at package view if it is set, change it to be able to set it when it is empty
 * Packages button (top right of stock.picking.form view) only shows packages, update it to also show parent packages

--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ This module adds the following features:
 
 
 ## To change
-* Change fields x_field_name to u_field_name
 * Stock.quant.packge has a field name called parent_ids but in the compute function uses ancestor_ids
 * Parent package is only shown at package view if it is set, change it to be able to set it when it is emptye
 * Packages button (top right of stock.picking.form view) only shows packages, update it to also show parent packages
-* x_selected still needed? Probably we can remove it and add it later if we need to palletise using UI

--- a/addons/package_hierarchy/models/stock_move_line.py
+++ b/addons/package_hierarchy/models/stock_move_line.py
@@ -7,8 +7,6 @@ from odoo.exceptions import ValidationError
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
-    x_selected = fields.Boolean(string=' ', help='Check this box to select')
-
     u_result_parent_package_id = fields.Many2one('stock.quant.package',
                     'Parent Destination Package', ondelete='restrict')
 

--- a/addons/package_hierarchy/models/stock_picking.py
+++ b/addons/package_hierarchy/models/stock_picking.py
@@ -5,26 +5,6 @@ from odoo.exceptions import UserError
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
-    x_pallet_id = fields.Many2one('stock.quant.package', 'Pallet:')
-
-    def palletise(self):
-        self.ensure_one()
-        if not self.x_pallet_id:
-            raise UserError(_('Select a pallet.'))
-
-        selected_lines = self.move_line_ids.filtered(lambda l: l.x_selected)
-        if not len(selected_lines):
-            # If there are no selected lines, palletise was a no-op.
-            # It wasn't intentionally being used that way, and is generally a
-            # sign that it's being called when it shouldn't be, eg after
-            # incorrect initialization, so it now raises an error instead of
-            # silently doing nothing.
-            raise UserError(_('palletise requires at least one selected line'))
-        selected_lines.mapped('result_package_id').write({'package_id': self.x_pallet_id.id})
-        self.x_pallet_id._check_not_multi_location()
-        self.move_line_ids.write({'x_selected': False})
-        self.x_pallet_id = None
-
     def _compute_entire_package_ids(self):
         """Add parent packages to picking."""
         super(StockPicking, self)._compute_entire_package_ids()

--- a/addons/package_hierarchy/views/stock_picking_views.xml
+++ b/addons/package_hierarchy/views/stock_picking_views.xml
@@ -5,15 +5,10 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="model">stock.picking</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='move_line_ids']//field[@name='product_id']" position="before">
-                <field name="x_selected" />
-            </xpath>
-
-            <xpath expr="//button[@name='put_in_pack']" position="before">
-                <field name="x_pallet_id" />
-                <button name="palletise" type="object" string="Palletise"/>
-            </xpath>
-
+            <!-- Two enters meant for removing the put_in_pack buttons
+                 from the 'Detailed Operations' and 'Operations' tabs -->
+            <xpath expr="//button[@name='put_in_pack']" position="replace" />
+            <xpath expr="//button[@name='put_in_pack']" position="replace" />
             <xpath expr="//field[@name='result_package_id']" position="after">
                 <field name="u_result_parent_package_id"
                     groups="stock.group_tracking_lot" />

--- a/addons/package_hierarchy/views/stock_picking_views.xml
+++ b/addons/package_hierarchy/views/stock_picking_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="model">stock.picking</field>
         <field name="arch" type="xml">
-            <!-- Two enters meant for removing the put_in_pack buttons
+            <!-- The two entries are meant for removing the put_in_pack buttons
                  from the 'Detailed Operations' and 'Operations' tabs -->
             <xpath expr="//button[@name='put_in_pack']" position="replace" />
             <xpath expr="//button[@name='put_in_pack']" position="replace" />

--- a/addons/package_hierarchy/views/stock_quant_views.xml
+++ b/addons/package_hierarchy/views/stock_quant_views.xml
@@ -5,8 +5,8 @@
         <field name="inherit_id" ref="stock.quant_package_search_view"/>
         <field name="model">stock.quant.package</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='name']" position="replace">
-                <field name="display_name" string="Package Name"/>
+            <xpath expr="//field[@name='name']" position="after">
+                <field name="package_id" string="Parent Package Name"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Here we remove the above buttons from the 'Detailed
Operations' and 'Operations' tabs in the picking
views, as well as the line selectors.

User-story: 1110
Task: 2706