### PR TITLE
[IMP] package_hierarchy: Override added for action_done in Stock Picking

### DIFF
--- a/addons/package_hierarchy/models/stock_picking.py
+++ b/addons/package_hierarchy/models/stock_picking.py
@@ -1,4 +1,4 @@
-from odoo import fields, models, _
+from odoo import fields, models, api, _
 from odoo.exceptions import UserError
 
 
@@ -43,3 +43,13 @@ class StockPicking(models.Model):
                     )
                     pack_mls.write({"u_result_parent_package_id": parent_package.id})
                     mls -= pack_mls
+
+    @api.multi
+    def action_done(self):
+        """
+        Override to initially bypass multi location check for quant packages and call it manually
+        once action_done is complete and all moves are in their new location.
+        """
+        res = super(StockPicking, self.with_context(bypass_multi_location_check=True)).action_done()
+        self.mapped("move_line_ids").mapped("package_id")._check_not_multi_location()
+        return res

--- a/addons/package_hierarchy/models/stock_quant_package.py
+++ b/addons/package_hierarchy/models/stock_quant_package.py
@@ -36,12 +36,13 @@ class QuantPackage(models.Model):
             raise ValidationError("A package cannot be its own parent.")
 
     def _check_not_multi_location(self):
-        for package in self:
-            locations = package.children_quant_ids.mapped('location_id')
-            if len(locations) > 1:
-                raise ValidationError(_('Package cannot be in multiple '
-                                        'locations:\n%s\n%s') % (package.name,
-                                                                 ', '.join( [l.name for l in locations])))
+        if not self.env.context.get("bypass_multi_location_check", False):
+            for package in self:
+                locations = package.children_quant_ids.mapped('location_id')
+                if len(locations) > 1:
+                    raise ValidationError(_('Package cannot be in multiple '
+                                            'locations:\n%s\n%s') % (package.name,
+                                                                    ', '.join( [l.name for l in locations])))
 
     @api.depends('package_id', 'children_ids')
     def _compute_parent_ids(self):


### PR DESCRIPTION
Added override for action_done in Stock Picking so that the multi location check on the Quant Package records is not carried out until the Stock Moves are completed.

Check for "bypass_multi_location_check" in context added to _check_not_multi_location method on Quant Package.

Story/11582

Signed-off-by: Peter Clark <peter.clark@unipart.io>