### PR TITLE
[IMP] package_hierarchy: Add parent package when preparing move lines

### DIFF
--- a/addons/package_hierarchy/models/__init__.py
+++ b/addons/package_hierarchy/models/__init__.py
@@ -1,3 +1,4 @@
+from . import stock_move
 from . import stock_move_line
 from . import stock_picking
 from . import stock_quant_package

--- a/addons/package_hierarchy/models/stock_move.py
+++ b/addons/package_hierarchy/models/stock_move.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):
+        """
+        Override to set result parent package in move lines if applicable.
+
+        If a parent package if set then also set the result package to avoid triggering an error
+        about trying to set a result parent package without a result package.
+        """
+        vals = super()._prepare_move_line_vals(quantity, reserved_quant)
+
+        if reserved_quant:
+            reserved_quant.ensure_one()
+
+            parent_package_id = (
+                reserved_quant.package_id.package_id.id if reserved_quant.package_id else False
+            )
+            if parent_package_id:
+                package_id = vals.get("package_id", False)
+                vals.update(
+                    {
+                        "result_package_id": package_id,
+                        "u_result_parent_package_id": parent_package_id,
+                    }
+                )
+
+        return vals


### PR DESCRIPTION
Pass through the parent package as the result parent package in _prepare_move_line_vals so that it gets set on newly created pickings.

Story/14902

Signed-off-by: Peter Clark <peter.clark@unipart.io>