### PR TITLE
[REM] package_hierarchy: Remove explicit utf-8 coding at top of Python files

### DIFF
--- a/addons/package_hierarchy/__init__.py
+++ b/addons/package_hierarchy/__init__.py
@@ -1,4 +1,2 @@
-# -*- coding: utf-8 -*-
-
 from . import models
 from . import tests

--- a/addons/package_hierarchy/__manifest__.py
+++ b/addons/package_hierarchy/__manifest__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {

--- a/addons/package_hierarchy/models/package_links.py
+++ b/addons/package_hierarchy/models/package_links.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from collections import defaultdict
 
 from odoo import api, models, fields, _

--- a/addons/package_hierarchy/models/res_users.py
+++ b/addons/package_hierarchy/models/res_users.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
 

--- a/addons/package_hierarchy/models/stock_move_line.py
+++ b/addons/package_hierarchy/models/stock_move_line.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError
 

--- a/addons/package_hierarchy/models/stock_warehouse.py
+++ b/addons/package_hierarchy/models/stock_warehouse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from odoo import fields, models
 
 

--- a/addons/package_hierarchy/tests/__init__.py
+++ b/addons/package_hierarchy/tests/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Package hierarchy tests"""
 
 from . import test_package_hierarchy

--- a/addons/package_hierarchy/tests/common.py
+++ b/addons/package_hierarchy/tests/common.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from odoo.tests import common, tagged
 
 @tagged('-at_install', 'post_install')


### PR DESCRIPTION
This has been deemed not required, so removing here to hopefully avoid more being added elsewhere.

Story/1088

Signed-off-by: Peter Clark <peter.clark@unipart.io>