### PR TITLE
[FIX] package_hierarchy: Including packages without pallets

### DIFF
--- a/addons/package_hierarchy/models/stock_quant_package.py
+++ b/addons/package_hierarchy/models/stock_quant_package.py
@@ -175,7 +175,7 @@ class QuantPackage(models.Model):
         MoveLine = self.env["stock.move.line"]
         action = self.env.ref("stock.action_picking_tree_all").read()[0]
 
-        packages = self.search([("id", "child_of", self.ids), ("package_id", "!=", False)])
+        packages = self.search([("id", "child_of", self.ids)])
         domain = [
             "|", ("result_package_id", "in", packages.ids), ("package_id", "in", packages.ids)
         ]


### PR DESCRIPTION
Removing search parameter about only packages with a parent package We want to show package transfers even if package is not linked with a parent package.
Story: 4031
Signed-off-by: Armand Cela <armand.cela@unipart.io>