### PR TITLE
[FIX] package_hierarchy: Filter out move lines to check 

### DIFF
--- a/addons/package_hierarchy/models/stock_picking.py
+++ b/addons/package_hierarchy/models/stock_picking.py
@@ -8,4 +8,7 @@ class StockPicking(models.Model):
     def _check_entire_pack(self):
         """Create links when moving entire parent packages."""
         super(StockPicking, self)._check_entire_pack()
-        self.move_line_ids.construct_package_hierarchy_links()
+        mls_to_check = self.move_line_ids
+        if self._context.get("check_mls"):
+            mls_to_check = mls_to_check.filtered(lambda ml: ml.id in self._context.get("check_mls"))
+        mls_to_check.construct_package_hierarchy_links()


### PR DESCRIPTION
at _check_entire_pack

Only need to construct_package_hierarchy_links for packages of the move lines that changed in the picking, which are provided in the context.

SE-1589
Signed-off-by: Miquel PS <miquel.palahi.sitges@unipart.io>